### PR TITLE
Use 'new Socket' instead of 'newSocket()'

### DIFF
--- a/blksrv.nim
+++ b/blksrv.nim
@@ -6,7 +6,7 @@ proc main(port : int) =
   var socket = newSocket()
   socket.bindAddr(Port(port))
   socket.listen()
-  var client = newSocket()
+  var client = new Socket
   var address = ""
   while true:
     echo("Waiting for connection...")


### PR DESCRIPTION
nim now requires use of 'new Socket' instead of 'newSocket()' to create a client socket.